### PR TITLE
Fix error when in maintenance mode

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1355,7 +1355,7 @@ function maintenance_message()
 	}
 	else
 	{
-		$tpl_file = FORUM_ROOT.'style/Core/template/maintenance.tpl';
+		$tpl_file = FORUM_ROOT.'style/Core/templates/maintenance.tpl';
 		$tpl_inc_dir = FORUM_ROOT.'style/User/';
 	}
 


### PR DESCRIPTION
This fixes an error when you put the forum into maintenance mode.
There was an incorrect file path set which produced this error when trying to view the forum then in maintenance mode (for users).

```
Warning: file_get_contents(/home/craigele/public_html/forum/style/Core/template/maintenance.tpl): failed to open stream: No such file or directory in /home/craigele/public_html/forum/include/functions.php on line 1362
```

This commit should fix that.
