### PR TITLE
Fix invalid edit preview path

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -155,7 +155,7 @@ if (!empty($errors))
 }
 else if (isset($_POST['preview']))
 {
-    require get_view_path('views/edit-preview.tpl.php');
+    require get_view_path('edit-preview.tpl.php');
 }
 
 require get_view_path('edit-form.tpl.php');


### PR DESCRIPTION
This commit fixes an invalid edit preview path, when editing a post you would get an error:

```
Warning: require(/home/craig/public_html/forum/style/Core/templates/views/views/edit-preview.tpl.php): failed to open stream: No such file or directory in /home/craig/public_html/forum/edit.php on line 158

Fatal error: require(): Failed opening required '/home/craig/public_html/forum/style/Core/templates/views/views/edit-preview.tpl.php' (include_path='.:/usr/lib/php:/usr/local/lib/php') in /home/craig/public_html/forum/edit.php on line 158
```
