### PR TITLE
Missing text definition "allow bbcode in user signatures" 

### DIFF
--- a/backstage/permissions.php
+++ b/backstage/permissions.php
@@ -139,7 +139,7 @@ if (isset($_GET['saved']))
                         <div class="checkbox">
                             <label>
                                 <input type="checkbox" name="form[sig_bbcode]" value="1" <?php if ($luna_config['p_sig_bbcode'] == '1') echo ' checked="checked"' ?> />
-                                <?php echo $lang['All caps sigs help'] ?>
+                                <?php echo $lang['BBCode sigs help'] ?>
                             </label>
                         </div>
                         <div class="checkbox">

--- a/lang/English/language.php
+++ b/lang/English/language.php
@@ -1442,6 +1442,7 @@ $lang = array(
 'All caps subject help'		=>	'Allow a subject to contain only capital letters.',
 'Require e-mail help'		=>	'Require guests to supply an email address when posting.',
 'Signatures subhead'		=>	'Signatures',
+'BBCode sigs help'			=>	'Allow BBCode in user signatures.',
 'Image tag sigs help'		=>	'Allow the BBCode [img] tag in user signatures (not recommended).',
 'All caps sigs help'		=>	'Allow a signature to contain only capital letters.',
 'Max sig length label'		=>	'Maximum signature length',


### PR DESCRIPTION
Used in backstage user permissions.
The "allow a signature to contain only capital letters" text definition was instead used twice.
