### PR TITLE
Fix tab links on help page

### DIFF
--- a/help.php
+++ b/help.php
@@ -206,6 +206,13 @@ if ($luna_user['is_admmod']) {
 		</div>
     </div>
 </div>
+<script type="text/javascript">
+	$(document).ready(function(){
+		$("#user").focus();
+		var hash = location.hash, hashPieces = hash.split('?'), activeTab = $('[href=' + hashPieces[0] + ']');
+		activeTab && activeTab.tab('show');
+	});
+</script>
 <?php
 }
 


### PR DESCRIPTION
This commit fixes links directed at the help page tabs by adding some javascript.

This was in a previous commit but it somehow got removed, probably when the editor was changed.
