### PR TITLE
Update POMO to support PHP 5.2 #1293

### DIFF
--- a/include/l10n.php
+++ b/include/l10n.php
@@ -1,8 +1,5 @@
 <?php
 
-use POMO\MO;
-use POMO\Translations\NOOPTranslations;
-
 function get_locale() {
 
 	global $luna_user;

--- a/include/pomo/MO.php
+++ b/include/pomo/MO.php
@@ -6,19 +6,11 @@
  * @license GPL
  */
 
-namespace POMO;
-
 require_once dirname(__FILE__) . '/Streams/Reader.php';
 require_once dirname(__FILE__) . '/Streams/FileReader.php';
 require_once dirname(__FILE__) . '/Translations/NOOPTranslations.php';
 require_once dirname(__FILE__) . '/Translations/GettextTranslations.php';
 require_once dirname(__FILE__) . '/Translations/EntryTranslations.php';
-
-use POMO\Streams\Reader;
-use POMO\Streams\FileReader;
-use POMO\Translations\NOOPTranslations;
-use POMO\Translations\GettextTranslations;
-use POMO\Translations\EntryTranslations;
 
 /**
  * Class for working with MO files

--- a/include/pomo/PO.php
+++ b/include/pomo/PO.php
@@ -6,11 +6,6 @@
  * @license GPL
  */
 
-namespace POMO;
-
-use POMO\Translations\GettextTranslations;
-use POMO\Translations\EntryTranslations;
-
 ini_set('auto_detect_line_endings', 1);
 
 /**
@@ -56,7 +51,7 @@ class PO extends GettextTranslations
     {
         //TODO: sorting
         return implode("\n\n", array_map(
-            array(__NAMESPACE__.'\PO', 'export_entry'),
+            array(__CLASS__, 'export_entry'),
             $this->entries)
         );
     }
@@ -167,7 +162,7 @@ class PO extends GettextTranslations
     {
         $escapes = array('t' => "\t", 'n' => "\n", '\\' => '\\');
         $lines = array_map('trim', explode("\n", $string));
-        $lines = array_map(array(__NAMESPACE__.'\PO', 'trim_quotes'), $lines);
+        $lines = array_map(array(__CLASS__, 'trim_quotes'), $lines);
         $unpoified = '';
         $previous_is_backslash = false;
         foreach ($lines as $line) {

--- a/include/pomo/Streams/CachedFileReader.php
+++ b/include/pomo/Streams/CachedFileReader.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Streams;
-
 /**
  * Reads the contents of the file in the beginning.
  *

--- a/include/pomo/Streams/CachedIntFileReader.php
+++ b/include/pomo/Streams/CachedIntFileReader.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Streams;
-
 /**
  * Reads the contents of the file in the beginning.
  *

--- a/include/pomo/Streams/FileReader.php
+++ b/include/pomo/Streams/FileReader.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Streams;
-
 /**
  * Classes, which help reading streams of data from files.
  *

--- a/include/pomo/Streams/Reader.php
+++ b/include/pomo/Streams/Reader.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Streams;
-
 /**
  * Classes, which help reading streams of data from files.
  *

--- a/include/pomo/Streams/StringReader.php
+++ b/include/pomo/Streams/StringReader.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Streams;
-
 /**
  * Provides file-like methods for manipulating a string instead
  * of a physical file.

--- a/include/pomo/Translations/EntryTranslations.php
+++ b/include/pomo/Translations/EntryTranslations.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Translations;
-
 /**
  * Contains EntryTranslations class
  * EntryTranslations class encapsulates a translatable string

--- a/include/pomo/Translations/GettextTranslations.php
+++ b/include/pomo/Translations/GettextTranslations.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Translations;
-
 require_once dirname(__FILE__) . '/Translations.php';
 
 /**

--- a/include/pomo/Translations/NOOPTranslations.php
+++ b/include/pomo/Translations/NOOPTranslations.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Translations;
-
 require_once dirname(__FILE__) . '/Translations.php';
 
 /**

--- a/include/pomo/Translations/Translations.php
+++ b/include/pomo/Translations/Translations.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Translations;
-
 require_once dirname(__FILE__) . '/TranslationsInterface.php';
 
 /**

--- a/include/pomo/Translations/TranslationsInterface.php
+++ b/include/pomo/Translations/TranslationsInterface.php
@@ -6,8 +6,6 @@
  * @license GPL
  */
 
-namespace POMO\Translations;
-
 /**
  * Translations Interface that all POMO Translators must implement
  *


### PR DESCRIPTION
Remove namespaces in POMO lib to support PHP 5.2