### PR TITLE
Make the forum usable with JavaScript disabled

### DIFF
--- a/backstage/header.php
+++ b/backstage/header.php
@@ -34,8 +34,14 @@ else
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="ROBOTS" content="NOINDEX, FOLLOW" />
 		<title><?php _e('Backstage', 'luna') ?></title>
+		<style>
+		body.js .hide-if-js, body.no-js .hide-if-no-js {
+			display: none !important;
+		}
+		</style>
 	</head>
-	<body>
+	<body class="no-js">
+		<script type="text/javascript">document.body.className = document.body.className.replace( 'no-js', 'js' );</script>
 <?php
 require_once FORUM_ROOT.'include/backstage_functions.php';
 

--- a/footer.php
+++ b/footer.php
@@ -44,5 +44,5 @@ if (!defined('FORUM'))
 			ajaxurl = '<?php echo get_base_url().'/ajax.php'; ?>';
 			l10n = {
 				no_notification: '<?php _e('No new notifications', 'luna'); ?>'
-			}
+			};
 		</script>

--- a/include/backstage_functions.php
+++ b/include/backstage_functions.php
@@ -115,10 +115,13 @@ function load_admin_nav($section, $page) {
 				</li>
 <?php } ?>
 			</ul>
+<?php
+$logout_url = '../login.php?action=out&amp;id='.$luna_user['id'].'&amp;csrf_token='.luna_hash($luna_user['id'].luna_hash(get_remote_address()));
+?>
 			<ul class="nav navbar-nav navbar-right">
 				<li class="dropdown usermenu">
-					<a href="#" class="dropdown-toggle dropdown-user" data-toggle="dropdown">
-						<span class="hidden-sm"><?php print(luna_htmlspecialchars($luna_user['username'])) ?> </span><?php echo draw_user_avatar($luna_user['id'], true, 'avatar'); ?> <span class="fa fa-fw fa-angle-down"></span>
+					<a href="../profile.php?id=<?php echo $luna_user['id'] ?>" class="dropdown-toggle dropdown-user" data-toggle="dropdown">
+						<span class="hidden-sm"><?php print(luna_htmlspecialchars($luna_user['username'])) ?> </span><?php echo draw_user_avatar($luna_user['id'], true, 'avatar'); ?> <span class="fa fa-fw fa-angle-down hide-if-no-js"></span>
 					</a>
 					<ul class="dropdown-menu">
 						<li><a href="../profile.php?id=<?php echo $luna_user['id'] ?>"><?php _e('Profile', 'luna') ?></a></li>
@@ -127,8 +130,13 @@ function load_admin_nav($section, $page) {
 						<li><a href="../help.php"><?php _e('Help', 'luna') ?></a></li>
 						<li><a href="http://getluna.org"><?php _e('Support', 'luna') ?></a></li>
 						<li class="divider"></li>
-						<li><a href="../login.php?action=out&amp;id=<?php echo ''.$luna_user['id'].'&amp;csrf_token='.luna_hash($luna_user['id'].luna_hash(get_remote_address())) ?>"><?php _e('Logout', 'luna') ?></a></li>
+						<li><a href="<?php echo $logout_url; ?>"><?php _e('Logout', 'luna') ?></a></li>
 					</ul>
+				</li>
+				<li id="navlogout" class="hide-if-js">
+					<a href="<?php echo $logout_url; ?>" title="<?php echo $item['logout']['title']; ?>">
+						<span class="fa fa-fw fa-sign-out"></span>
+					</a>
 				</li>
 			</ul>
 		</div>

--- a/include/draw_functions.php
+++ b/include/draw_functions.php
@@ -79,7 +79,10 @@ function draw_editor($height) {
 <div class="panel panel-default panel-editor">
 	<fieldset class="postfield">
 		<input type="hidden" name="form_sent" value="1" />
-		<div class="btn-toolbar textarea-toolbar textarea-top">
+		<div class="alert alert-warning hide-if-js" role="alert">
+			<p><?php _e('The Editor Toolbar requires JavaScript to be enabled. BBCode will still work, though.', 'luna' ); ?></p>
+		</div>
+		<div class="btn-toolbar textarea-toolbar textarea-top hide-if-no-js">
 			<?php echo $pin_btn ?>
 			<?php echo $silence_btn ?>
 			<div class="btn-group">

--- a/include/draw_functions.php
+++ b/include/draw_functions.php
@@ -194,6 +194,12 @@ function AddTag(type, tag) {
 
 	document.getElementById('post_field').focus();
 }
+window.onbeforeunload = function() {
+    if ( document.getElementById('post_field').value ) {
+	// Don't translate this; we can't change the confirm text anyway.
+	return 'Unsaved changes!';
+    }
+}
 </script>
 <?php
 }

--- a/include/general_functions.php
+++ b/include/general_functions.php
@@ -46,7 +46,7 @@ function get_user_nav_menu_items() {
 		$num_notifications = intval($db->result($result));
 
 		$items['notifications'] = array(
-			'url'    => $luna_config['o_notification_flyout'] ? '#' : 'notifications.php',
+			'url'    => 'notifications.php',
 			'title'  => $num_notifications > 0 ? __('Notifications', 'luna') : __('No new notifications', 'luna'),
 			'num'    => $num_notifications,
 			'flyout' => 1 == $luna_config['o_notification_flyout']

--- a/post.php
+++ b/post.php
@@ -456,7 +456,7 @@ Post URL: <post_url>
 // If a topic ID was specified in the url (it's a reply)
 if ($tid) {
 	$action = __('Post a reply', 'luna');
-	$form = '<form id="post" method="post" action="post.php?action=post&amp;tid='.$tid.'" onsubmit="this.submit.disabled=true;if(process_form(this)){return true;}else{this.submit.disabled=false;return false;}">';
+	$form = '<form id="post" method="post" action="post.php?action=post&amp;tid='.$tid.'" onsubmit="window.onbeforeunload=null;this.submit.disabled=true;if(process_form(this)){return true;}else{this.submit.disabled=false;return false;}">';
 
 	// If a quote ID was specified in the url
 	if (isset($_GET['qid'])) {
@@ -523,7 +523,7 @@ if ($tid) {
 // If a forum ID was specified in the url (new topic)
 elseif ($fid) {
 	$action = __('Post topic', 'luna');
-	$form = '<form id="post" method="post" action="post.php?action=post&amp;fid='.$fid.'" onsubmit="return process_form(this)">';
+	$form = '<form id="post" method="post" action="post.php?action=post&amp;fid='.$fid.'" onsubmit="window.onbeforeunload=null;return process_form(this)">';
 } else
 	message(__('Bad request. The link you followed is incorrect, outdated or you are simply not allowed to hang around here.', 'luna'), false, '404 Not Found');
 

--- a/themes/Fifteen/footer.php
+++ b/themes/Fifteen/footer.php
@@ -94,7 +94,7 @@ if (($luna_config['o_feed_type'] == 1 || $luna_config['o_feed_type'] == 2) && (i
 										<?php if ($luna_config['o_users_online']) { ?>
 										<div class="dropup">
 											<a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-												<?php echo _n('User online', 'Users online', num_users_online(), 'luna') ?> <span class="fa fa-fw fa-angle-up"></span>
+												<?php echo _n('User online', 'Users online', num_users_online(), 'luna') ?> <span class="fa fa-fw fa-angle-up hide-if-no-js"></span>
 												<span class="sr-only">Toggle Dropdown</span>
 											</a>
 											<ul class="dropdown-menu" role="menu">

--- a/themes/Fifteen/header.php
+++ b/themes/Fifteen/header.php
@@ -17,9 +17,13 @@ $body_classes = check_night_mode();
 		.emoji {
 			font-size: <?php echo $luna_config['o_emoji_size'] ?>px;
 		}
+		body.js .hide-if-js, body.no-js .hide-if-no-js {
+			display: none !important;
+		}
 		</style>
 	</head>
-	<body>
+	<body class="no-js">
+		<script type="text/javascript">document.body.className = document.body.className.replace( 'no-js', 'js' );</script>
 		<?php if ($luna_user['is_guest']): require load_page('login.php'); endif; ?>
 		<div class="container container-main" id="main">
 			<div id="header">

--- a/themes/Fifteen/objects/user-navmenu.php
+++ b/themes/Fifteen/objects/user-navmenu.php
@@ -35,7 +35,7 @@ if (!empty($items['guest'])) {
 	$item = $items['user'];
 ?>
 								<li id="navprofile" class="dropdown">
-									<a href="#" class="dropdown-toggle avatar-item" data-toggle="dropdown"><?php echo luna_htmlspecialchars($luna_user['username']); ?> <?php echo draw_user_avatar($luna_user['id'], true, 'avatar'); ?> <span class="fa fa-fw fa-angle-down"></span></a>
+									<a href="<?php echo $item['profile']['url']; ?>" class="dropdown-toggle avatar-item" data-toggle="dropdown"><?php echo luna_htmlspecialchars($luna_user['username']); ?> <?php echo draw_user_avatar($luna_user['id'], true, 'avatar'); ?> <span class="fa fa-fw fa-angle-down hide-if-no-js"></span></a>
 									<ul class="dropdown-menu">
 										<li><a href="<?php echo $item['profile']['url']; ?>"><?php echo $item['profile']['title']; ?></a></li>
 										<li><a href="<?php echo $item['settings']['url']; ?>"><?php echo $item['settings']['title']; ?></a></li>
@@ -44,6 +44,11 @@ if (!empty($items['guest'])) {
 										<li class="divider"></li>
 										<li><a href="<?php echo $item['logout']['url']; ?>"><?php echo $item['logout']['title']; ?></a></li>
 									</ul>
+								</li>
+								<li id="navlogout" class="hide-if-js">
+									<a href="<?php echo $item['logout']['url']; ?>" title="<?php echo $item['logout']['title']; ?>">
+										<span class="fa fa-fw fa-sign-out"></span>
+									</a>
 								</li>
 <?php } ?>
 							</ul>

--- a/themes/Fifteen/settings.php
+++ b/themes/Fifteen/settings.php
@@ -4,6 +4,13 @@
 if (!defined('FORUM'))
 	exit;
 
+$sections = array( 'profile', 'personalize', 'email', 'contact', 'threads', 'time', 'admin' );
+if ( isset( $_GET['section'] ) && in_array( $_GET['section'], $sections ) ) {
+	$section = luna_htmlspecialchars( $_GET['section'] );
+} else {
+	$section = 'profile';
+}
+
 ?>
 <div class="col-sm-3 profile-nav">
 	<div class="user-card-profile">
@@ -37,19 +44,19 @@ if (!defined('FORUM'))
 		</div>
 	</nav>
 	<div role="tabpanel">
-		<ul class="nav nav-tabs" role="tablist">
-			<li role="presentation" class="active"><a href="#profile" aria-controls="profile" role="tab" data-toggle="tab"><span class="fa fa-fw fa-user"></span><span class="hidden-xs"> <?php _e('Profile', 'luna') ?></span></a></li>
-			<li role="presentation"><a href="#personalize" aria-controls="personalize" role="tab" data-toggle="tab"><span class="fa fa-fw fa-paint-brush"></span><span class="hidden-xs"> <?php _e('Personalize', 'luna') ?></span></a></li>
-			<li role="presentation"><a href="#email" aria-controls="email" role="tab" data-toggle="tab"><span class="fa fa-fw fa-envelope-o"></span><span class="hidden-xs"> <?php _e('Message', 'luna') ?></span></a></li>
-			<li role="presentation"><a href="#contact" aria-controls="contact" role="tab" data-toggle="tab"><span class="fa fa-fw fa-share-alt"></span><span class="hidden-xs"> <?php _e('Contact', 'luna') ?></span></a></li>
-			<li role="presentation"><a href="#threads" aria-controls="threads" role="tab" data-toggle="tab"><span class="fa fa-fw fa-list"></span><span class="hidden-xs"> <?php _e('Threads', 'luna') ?></span></a></li>
-			<li role="presentation"><a href="#time" aria-controls="time" role="tab" data-toggle="tab"><span class="fa fa-fw fa-clock-o"></span><span class="hidden-xs"> <?php _e('Time', 'luna') ?></span></a></li>
+		<ul id="profilenav" class="nav nav-tabs" role="tablist">
+			<li role="presentation"<?php if ( 'profile' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=profile#profile" aria-controls="profile" role="tab" data-toggle="tab"><span class="fa fa-fw fa-user"></span><span class="hidden-xs"> <?php _e('Profile', 'luna') ?></span></a></li>
+			<li role="presentation"<?php if ( 'personalize' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=personalize#personalize" aria-controls="personalize" role="tab" data-toggle="tab"><span class="fa fa-fw fa-paint-brush"></span><span class="hidden-xs"> <?php _e('Personalize', 'luna') ?></span></a></li>
+			<li role="presentation"<?php if ( 'email' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=email#email" aria-controls="email" role="tab" data-toggle="tab"><span class="fa fa-fw fa-envelope-o"></span><span class="hidden-xs"> <?php _e('Message', 'luna') ?></span></a></li>
+			<li role="presentation"<?php if ( 'contact' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=contact#contact" aria-controls="contact" role="tab" data-toggle="tab"><span class="fa fa-fw fa-share-alt"></span><span class="hidden-xs"> <?php _e('Contact', 'luna') ?></span></a></li>
+			<li role="presentation"<?php if ( 'threads' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=threads#threads" aria-controls="threads" role="tab" data-toggle="tab"><span class="fa fa-fw fa-list"></span><span class="hidden-xs"> <?php _e('Threads', 'luna') ?></span></a></li>
+			<li role="presentation"<?php if ( 'time' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=time#time" aria-controls="time" role="tab" data-toggle="tab"><span class="fa fa-fw fa-clock-o"></span><span class="hidden-xs"> <?php _e('Time', 'luna') ?></span></a></li>
 			<?php if ($luna_user['g_id'] == FORUM_ADMIN || ($luna_user['g_moderator'] == '1' && $luna_user['g_mod_ban_users'] == '1')): ?>
-				<li role="presentation"><a href="#admin" aria-controls="admin" role="tab" data-toggle="tab"><span class="fa fa-fw fa-dashboard"></span><span class="hidden-xs"> <?php _e('Admin', 'luna') ?></span></a></li>
+				<li role="presentation"<?php if ( 'admin' === $section ) { ?> class="active"<?php } ?>><a href="settings.php?id=<?php echo $id ?>&amp;section=admin#admin" aria-controls="admin" role="tab" data-toggle="tab"><span class="fa fa-fw fa-dashboard"></span><span class="hidden-xs"> <?php _e('Admin', 'luna') ?></span></a></li>
 			<?php endif; ?>
 		</ul>
 		<div class="tab-content">
-			<div role="tabpanel" class="tab-pane active" id="profile">
+			<div role="tabpanel" class="tab-pane<?php if ( 'profile' === $section ) { ?> active<?php } ?>" id="profile">
 				<fieldset class="form-horizontal form-setting">
 					<input type="hidden" name="form_sent" value="1" />
 					<div class="form-group">
@@ -122,7 +129,7 @@ if (!defined('FORUM'))
 					</div>
 				</fieldset>
 			</div>
-			<div role="tabpanel" class="tab-pane" id="personalize">
+			<div role="tabpanel" class="tab-pane<?php if ( 'personalize' === $section ) { ?> active<?php } ?>" id="personalize">
 				<fieldset class="form-horizontal form-setting">
 <?php if ($luna_config['o_allow_accent_color'] == '1') { ?>
 					<div class="form-group">
@@ -213,7 +220,7 @@ if (count($languages) > 1) {
 <?php } ?>
 				</fieldset>
 			</div>
-			<div role="tabpanel" class="tab-pane" id="email">
+			<div role="tabpanel" class="tab-pane<?php if ( 'email' === $section ) { ?> active<?php } ?>" id="email">
 				<fieldset class="form-horizontal form-setting">
 					<?php if ($luna_config['o_pms_enabled'] == 1) { ?>
 					<div class="form-group">
@@ -272,7 +279,7 @@ if (count($languages) > 1) {
 					</div>
 				</fieldset>
 			</div>
-			<div role="tabpanel" class="tab-pane" id="contact">
+			<div role="tabpanel" class="tab-pane<?php if ( 'contact' === $section ) { ?> active<?php } ?>" id="contact">
 				<fieldset class="form-horizontal form-setting">
 					<div class="form-group">
 						<label class="col-sm-3 control-label"><?php _e('Website', 'luna') ?></label>
@@ -322,7 +329,7 @@ if (count($languages) > 1) {
 					</div>
 				</fieldset>
 			</div>
-			<div role="tabpanel" class="tab-pane" id="threads">
+			<div role="tabpanel" class="tab-pane<?php if ( 'threads' === $section ) { ?> active<?php } ?>" id="threads">
 				<fieldset class="form-horizontal form-setting">
 					<?php if ($luna_config['o_smilies_sig'] == '1' || $luna_config['o_signatures'] == '1' || $luna_config['o_avatars'] == '1' || $luna_config['p_message_img_tag'] == '1'): ?>
 						<div class="form-group">
@@ -382,7 +389,7 @@ if (count($languages) > 1) {
 					</div>
 				</fieldset>
 			</div>
-			<div role="tabpanel" class="tab-pane" id="time">
+			<div role="tabpanel" class="tab-pane<?php if ( 'time' === $section ) { ?> active<?php } ?>" id="time">
 				<fieldset class="form-horizontal form-setting">
 					<div class="form-group">
 						<label class="col-sm-3 control-label"><?php _e('Time zone', 'luna') ?></label>
@@ -476,7 +483,7 @@ if (count($languages) > 1) {
 				</fieldset>
 			</div>
 			<?php if ($luna_user['g_id'] == FORUM_ADMIN || ($luna_user['g_moderator'] == '1' && $luna_user['g_mod_ban_users'] == '1')): ?>
-			<div role="tabpanel" class="tab-pane" id="admin">
+			<div role="tabpanel" class="tab-pane<?php if ( 'admin' === $section ) { ?> active<?php } ?>" id="admin">
 				<fieldset class="form-horizontal form-setting">
 					<?php if ($luna_user['g_moderator'] == '1') { ?>
 						<div class="form-group">

--- a/themes/Fifteen/thread.php
+++ b/themes/Fifteen/thread.php
@@ -49,7 +49,7 @@ if (!defined('FORUM'))
 		</div>
 		<?php draw_comment_list(); ?>
 		<?php if ($quickpost): ?>
-			<form method="post" action="post.php?tid=<?php echo $id ?>" onsubmit="this.submit.disabled=true;if(process_form(this)){return true;}else{this.submit.disabled=false;return false;}">
+			<form method="post" action="post.php?tid=<?php echo $id ?>" onsubmit="window.onbeforeunload=null;this.submit.disabled=true;if(process_form(this)){return true;}else{this.submit.disabled=false;return false;}">
 <?php
 			if ($luna_user['is_guest']) {
 				$email_label = ($luna_config['p_force_guest_email'] == '1') ? '<strong>'.__('Email', 'luna').'</strong>' : __('Email', 'luna');

--- a/themes/Sunrise/header.php
+++ b/themes/Sunrise/header.php
@@ -17,9 +17,13 @@ $body_classes = check_night_mode();
 		.emoji {
 			font-size: <?php echo $luna_config['o_emoji_size'] ?>px;
 		}
+		body.js .hide-if-js, body.no-js .hide-if-no-js {
+			display: none !important;
+		}
 		</style>
 	</head>
-	<body>
+	<body class="no-js">
+		<script type="text/javascript">document.body.className = document.body.className.replace( 'no-js', 'js' );</script>
 		<?php if ($luna_user['is_guest']): require load_page('login.php'); endif; ?>
 		<div class="container container-main" id="main">
 			<div id="header">

--- a/themes/Sunrise/thread.php
+++ b/themes/Sunrise/thread.php
@@ -48,7 +48,7 @@ if (!defined('FORUM'))
 			<h2><?php echo luna_htmlspecialchars($cur_topic['subject']) ?></h2>
 		</div>
 		<?php draw_comment_list(); ?>
-		<form method="post" action="post.php?tid=<?php echo $id ?>" onsubmit="this.submit.disabled=true;if(process_form(this)){return true;}else{this.submit.disabled=false;return false;}">
+		<form method="post" action="post.php?tid=<?php echo $id ?>" onsubmit="window.onbeforeunload=null;this.submit.disabled=true;if(process_form(this)){return true;}else{this.submit.disabled=false;return false;}">
 		<?php draw_editor('10'); ?>
 		</form>
 		<div class="pull-right"><?php echo $paging_links ?></div>


### PR DESCRIPTION
Luna relies on Bootstrap for some actions, making it hard to use when JavaScript is disabled. The profile tabs and user menu will not work, for instance, preventing users from editing their profile or even log out.

Details: I added a WordPress-like duet of classes, `hide-if-js` and `hide-if-no-js`; a `no-js` class is set to `body` and turned to `js` right after loading. Elements with a `hide-if-no-js` will be hidden if `body` has a `no-js` class set, while elements with a `hide-if-js` will be hidden if `body` has a `js` class set. This way we can easily chose what should or should be displayed on a JS enabled/disabled context.