### PR TITLE
Implement nonces on edit/post forms (#1342 #1248) + fix JS onbeforeunload overuse

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -52,7 +52,8 @@ $errors = array();
 
 if (isset($_POST['form_sent'])) {
 	// Make sure they got here from the site
-	confirm_referrer('edit.php');
+	if (!isset($_POST['_luna_nonce_edit_post']) || !LunaNonces::verify($_POST['_luna_nonce_edit_post'],'edit-post'))
+		message(__('Are you sure you want to do this?', 'luna'));
 
 	// If it's a topic it must contain a subject
 	if ($can_edit_subject) {

--- a/include/class/luna_nonces.php
+++ b/include/class/luna_nonces.php
@@ -167,6 +167,29 @@ class LunaNonces {
 	}
 
 	/**
+	 * Output a nonce field.
+	 * 
+	 * Create a HTML <INPUT> field to store the nonce. If no name is set for
+	 * the field, generate a default one based on the action.
+	 * 
+	 * @since    1.1
+	 * 
+	 * @param    string     $action Nonce action
+	 * @param    string     $name Name of the field
+	 * 
+	 * @return   void
+	 */
+	private function _field($name = null) {
+
+		$nonce = $this->_create();
+		if ( is_null( $name ) ) {
+			$name = '_luna_nonce_' . str_replace( '-', '_', strtolower( $this->action ) );
+		}
+
+		echo '<input type="hidden" name="' . $name . '" value="' . $nonce . '"/>';
+	}
+
+	/**
 	 * Check a nonce validity.
 	 * 
 	 * Create a temporary valid nonce, match it against the submitted nonce
@@ -229,6 +252,24 @@ class LunaNonces {
 		$check->_verify($nonce);
 
 		return $check;
+	}
+
+	/**
+	 * Output a nonce field.
+	 * 
+	 * This method is static and can be called publicly.
+	 * 
+	 * @since    1.1
+	 * 
+	 * @param    string     $action Nonce action
+	 * @param    string     $name Name of the field
+	 * 
+	 * @return   void
+	 */
+	public static function field($action = -1, $name = null) {
+
+		$nonce = new LunaNonces($action);
+		$nonce = $nonce->_field($name);
 	}
 
 	/**

--- a/include/draw_functions.php
+++ b/include/draw_functions.php
@@ -168,10 +168,19 @@ function draw_editor($height) {
 			elseif (FORUM_ACTIVE_PAGE == 'new-inbox')
 				echo luna_htmlspecialchars(isset($p_message) ? $p_message : '');
 		?></textarea>
+		<?php
+			if (FORUM_ACTIVE_PAGE == 'edit')
+				$action = 'edit-post';
+			elseif (FORUM_ACTIVE_PAGE == 'new-inbox')
+				$action = 'post-message';
+			else
+				$action = ($fid ? 'post-topic' : 'post-reply');
+			LunaNonces::field($action);
+		?>
 		<div class="btn-toolbar textarea-toolbar textarea-bottom">
 			<div class="btn-group pull-right">
-				<button class="btn btn-with-text btn-default" type="submit" name="preview" accesskey="p" tabindex="<?php echo $cur_index++ ?>"><span class="fa fa-fw fa-eye"></span> <?php _e('Preview', 'luna') ?></button>
-				<button class="btn btn-with-text btn-primary" type="submit" name="submit" accesskey="s" tabindex="<?php echo $cur_index++ ?>"><span class="fa fa-fw fa-plus"></span> <?php _e('Submit', 'luna') ?></button>
+				<button class="btn btn-with-text btn-default" type="submit" name="preview" accesskey="p" tabindex="<?php echo $cur_index++ ?>" onclick="window.onbeforeunload=null"><span class="fa fa-fw fa-eye"></span> <?php _e('Preview', 'luna') ?></button>
+				<button class="btn btn-with-text btn-primary" type="submit" name="submit" accesskey="s" tabindex="<?php echo $cur_index++ ?>" onclick="window.onbeforeunload=null"><span class="fa fa-fw fa-plus"></span> <?php _e('Submit', 'luna') ?></button>
 			</div>
 		</div>
 	</fieldset>

--- a/post.php
+++ b/post.php
@@ -54,7 +54,9 @@ if (isset($_POST['form_sent'])) {
 		$errors[] = sprintf(__('At least %s seconds have to pass between posts. Please wait %s seconds and try posting again.', 'luna'), $luna_user['g_post_flood'], $luna_user['g_post_flood'] - (time() - $luna_user['last_post']));
 
 	// Make sure they got here from the site
-	confirm_referrer(array('post.php', 'viewtopic.php'));
+	if (($fid && (!isset($_POST['_luna_nonce_post_topic']) || !LunaNonces::verify($_POST['_luna_nonce_post_topic'],'post-reply'))) ||
+	   (!$fid && (!isset($_POST['_luna_nonce_post_reply']) || !LunaNonces::verify($_POST['_luna_nonce_post_reply'],'post-reply'))))
+		message(__('Are you sure you want to do this?', 'luna'));
 
 	// If it's a new topic
 	if ($fid) {


### PR DESCRIPTION
Replace `confirm_referrer()` with a nonce check on post/edit forum (#1342), and fix a JS overuse of onbeforeunload: clicking "Submit" and "Preview" buttons shouldn't bring up a confirm.